### PR TITLE
Something needs to be updated because of new Helm version

### DIFF
--- a/pkg/connectors/common.go
+++ b/pkg/connectors/common.go
@@ -16,6 +16,10 @@ import (
 
 const (
 	defaultTillerPort = 44134
+	// maxReceiveMsgSize uses 20MB as the default message size limit.
+	// the gRPC's default size is 4MB.
+	// Since Tiller has been change the messages' size to 20MB, so we should make this value to 20MB.
+	maxReceiveMsgSize = 1024 * 1024 * 20
 )
 
 var (
@@ -38,6 +42,7 @@ func Connect(cfg Config) (conn *grpc.ClientConn, err error) {
 		grpc.WithBlock(), // required for timeout
 		grpc.WithUnaryInterceptor(grpc_glog.UnaryClientInterceptor(glogEntry, optsGLog...)),
 		grpc.WithStreamInterceptor(grpc_glog.StreamClientInterceptor(glogEntry, optsGLog...)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxReceiveMsgSize)),
 	}
 	if cfg.InsecureSkipVerify {
 		opts = append(opts, grpc.WithInsecure())

--- a/pkg/release/server.go
+++ b/pkg/release/server.go
@@ -51,6 +51,9 @@ func (s *Server) SummarizeReleases(ctx context.Context, req *proto.SummarizeRele
 			hrls.Status_SUPERSEDED,
 			hrls.Status_FAILED,
 			hrls.Status_DELETING,
+			hrls.Status_PENDING_INSTALL,
+			hrls.Status_PENDING_UPGRADE,
+			hrls.Status_PENDING_ROLLBACK,
 		}
 	} else { // convert status(string) to status-code(int32)
 		for _, status := range req.StatusCodes {


### PR DESCRIPTION
Hi, Because this project is based on an old Helm version. But the Helm version is a newer one,
so we need to update some code.
1. 
Reason:  There are new status for Helm release: Status_PENDING_INSTALL, Status_PENDING_UPGRADE, Status_PENDING_ROLLBACK.

Fixes:  Add these status when listing SummarizeReleases with "all=true"
2. 
Reason:  The API "ListReleases" on Tiller side now is a Stream service for larger response data.

Fixes: Make client using stream service as well as Tiller when listing SummarizeReleases.
3.
Reason: The gRPC's default Message size limit  is 4MB. it's too small. now the Tiller's side is 20MB as default for larger data.

Fixes: Make client using 20MB as the default value of MaxCallRecvMsgSize to match Tiller's value.

here is the link for No.3:
https://github.com/helm/helm/pull/3528