### PR TITLE
Use absolute path as aliases for reference docs

### DIFF
--- a/docs/reference/swift.md
+++ b/docs/reference/swift.md
@@ -11,7 +11,7 @@ product_name: swift
 menu_name: product_swift_0.11.1
 section_menu_id: reference
 aliases:
-  - products/swift/0.11.1/reference/
+  - /products/swift/0.11.1/reference/
 
 ---
 ## swift

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -47,7 +47,7 @@ menu_name: product_swift_{{ .Version }}
 section_menu_id: reference
 {{- if .RootCmd }}
 aliases:
-  - products/swift/{{ .Version }}/reference/
+  - /products/swift/{{ .Version }}/reference/
 {{ end }}
 ---
 `))


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>